### PR TITLE
Fill empty message fields

### DIFF
--- a/src/publisher.cpp
+++ b/src/publisher.cpp
@@ -149,14 +149,14 @@ void Publisher::packetReady(
   const std::string & frame_id, const rclcpp::Time & stamp, const std::string & codec,
   uint32_t width, uint32_t height, uint64_t pts, uint8_t flags, uint8_t * data, size_t sz)
 {
-  (void)frame_id;
-  (void)stamp;
   (void)codec;
   (void)pts;
   (void)flags;
   (void)width;
   (void)height;
   auto msg = std::make_shared<CompressedVideo>();
+  msg->frame_id = frame_id;
+  msg->timestamp = stamp;
   msg->format = "h264";
   msg->data.assign(data, data + sz);
 

--- a/src/subscriber.cpp
+++ b/src/subscriber.cpp
@@ -86,6 +86,7 @@ void Subscriber::internalCallback(const CompressedVideoConstPtr & msg, const Cal
     }
   }
   decoder_.decodePacket(
-    msg->format, &msg->data[0], msg->data.size(), pts_++, msg->frame_id.c_str(), rclcpp::Time(msg->timestamp));
+    msg->format, &msg->data[0], msg->data.size(), pts_++, msg->frame_id.c_str(),
+    rclcpp::Time(msg->timestamp));
 }
 }  // namespace foxglove_compressed_video_transport

--- a/src/subscriber.cpp
+++ b/src/subscriber.cpp
@@ -86,6 +86,6 @@ void Subscriber::internalCallback(const CompressedVideoConstPtr & msg, const Cal
     }
   }
   decoder_.decodePacket(
-    msg->format, &msg->data[0], msg->data.size(), pts_++, "", node_->get_clock()->now());
+    msg->format, &msg->data[0], msg->data.size(), pts_++, msg->frame_id.c_str(), rclcpp::Time(msg->timestamp));
 }
 }  // namespace foxglove_compressed_video_transport


### PR DESCRIPTION
Added missing implementation to fill empty ROS message fields for the Publisher and the Subscriber.

Signed-off-by: Jan Vojnar <electrygit@outlook.com>