### PR TITLE
Fix segfault

### DIFF
--- a/src/publisher.cpp
+++ b/src/publisher.cpp
@@ -199,8 +199,8 @@ rmw_qos_profile_t Publisher::initialize(
 void Publisher::publish(const Image & msg, const PublishFn & publish_fn) const
 {
   Publisher * me = const_cast<Publisher *>(this);
+  me->publishFunction_ = &publish_fn;
   if (!me->encoder_.isInitialized()) {
-    me->publishFunction_ = &publish_fn;
     if (!me->encoder_.initialize(
           msg.width, msg.height,
           std::bind(&Publisher::packetReady, me, _1, _2, _3, _4, _5, _6, _7, _8, _9))) {


### PR DESCRIPTION
In my setup under Jazzy, `foxglove_compressed_video_transport` always segfaults after receiving several frames. See the backtrace below. It turns out that the `publish_fn` address passed to `Publisher::publish()` can be different in every invocation. Therefore, storing the value during initialization is not sufficient and we have to do for every frame.

    #0  0x00007ff8c7da8f80 in ?? ()
    #1  0x00007fff813feede in std::function<void(foxglove_msgs::msg::CompressedVideo_<std::allocator<void> > const&)>::operator() (this=<optimized out>, __args#0=...)
        at /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/std_function.h:591
    #2  foxglove_compressed_video_transport::Publisher::packetReady (this=0xa3e450, frame_id=..., stamp=..., codec=..., width=<optimized out>, height=<optimized out>, pts=0,
        flags=1 '\001', data=0x7fff44194140 "", sz=73604) at /home/ros/devel/src/foxglove_compressed_video_transport/src/publisher.cpp:163
    #3  0x00007fff812f1a75 in ffmpeg_encoder_decoder::Encoder::drainPacket(std_msgs::msg::Header_<std::allocator<void> > const&, int, int) ()
       from /nix/store/w84wzlpj2c6gk1mikx22dcxq5wi6mhbq-ros-env/lib/libffmpeg_encoder_decoder.so
    #4  0x00007fff812f2470 in ffmpeg_encoder_decoder::Encoder::encodeImage(cv::Mat const&, std_msgs::msg::Header_<std::allocator<void> > const&, rclcpp::Time const&) ()
       from /nix/store/w84wzlpj2c6gk1mikx22dcxq5wi6mhbq-ros-env/lib/libffmpeg_encoder_decoder.so
    #5  0x00007fff812f2880 in ffmpeg_encoder_decoder::Encoder::encodeImage(sensor_msgs::msg::Image_<std::allocator<void> > const&) ()
       from /nix/store/w84wzlpj2c6gk1mikx22dcxq5wi6mhbq-ros-env/lib/libffmpeg_encoder_decoder.so
    #6  0x00007fff813ff0f7 in foxglove_compressed_video_transport::Publisher::publish (this=this@entry=0xa3e450, msg=..., publish_fn=...)
        at /home/wsh/projects/certicar/devel/ros2_ws/src/foxglove_compressed_video_transport/src/publisher.cpp:212
    #7  0x00007fff8140792e in image_transport::SimplePublisherPlugin<foxglove_msgs::msg::CompressedVideo_<std::allocator<void> > >::publish (this=0xa3e450, message=..., publisher=...)
        at /nix/store/w84wzlpj2c6gk1mikx22dcxq5wi6mhbq-ros-env/include/image_transport/image_transport/simple_publisher_plugin.hpp:160
    #8  image_transport::SimplePublisherPlugin<foxglove_msgs::msg::CompressedVideo_<std::allocator<void> > >::publish (this=0xa3e450, message=...)
        at /nix/store/w84wzlpj2c6gk1mikx22dcxq5wi6mhbq-ros-env/include/image_transport/image_transport/simple_publisher_plugin.hpp:94
    #9  0x00007ffff7da268a in image_transport::Publisher::publish(sensor_msgs::msg::Image_<std::allocator<void> > const&) const ()
       from /nix/store/w84wzlpj2c6gk1mikx22dcxq5wi6mhbq-ros-env/lib/libimage_transport.so
    #10 0x00007ffff7db31da in image_transport::CameraPublisher::publish(sensor_msgs::msg::Image_<std::allocator<void> >&, sensor_msgs::msg::CameraInfo_<std::allocator<void> >&, rclcpp::Time) const () from /nix/store/w84wzlpj2c6gk1mikx22dcxq5wi6mhbq-ros-env/lib/libimage_transport.so
    #11 0x000000000050f952 in ros_publish (stamp=<optimized out>, w=<optimized out>, h=<optimized out>, fov=<optimized out>, data=<optimized out>)
        at /home/wsh/projects/certicar/devel/ros2_ws/src/carla_camera_publisher/ros.cpp:145
    #12 0x000000000050d361 in operator()<boost::shared_ptr<carla::sensor::SensorData> > (__closure=<optimized out>, data=...)
        at /home/wsh/projects/certicar/devel/ros2_ws/src/carla_camera_publisher/main.cpp:157
    #13 std::__invoke_impl<void, main(int, char const**)::<lambda(auto:261)>&, boost::shared_ptr<carla::sensor::SensorData> > (__f=...)
        at /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/invoke.h:61
    #14 std::__invoke_r<void, main(int, char const**)::<lambda(auto:261)>&, boost::shared_ptr<carla::sensor::SensorData> > (__fn=...)
        at /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/invoke.h:111
    #15 std::_Function_handler<void(boost::shared_ptr<carla::sensor::SensorData>), main(int, char const**)::<lambda(auto:261)> >::_M_invoke(const std::_Any_data &, boost::shared_ptr<carla::sensor::SensorData> &&) (__functor=..., __args#0=...) at /nix/store/aw0qxjd1phf16qhlwpdb4x87yymfv9rp-gcc-14-20241116/include/c++/14-20241116/bits/std_function.h:290
    #16 0x000000000058568f in std::_Function_handler<void (carla::Buffer), carla::client::detail::Simulator::SubscribeToSensor(carla::client::Sensor const&, std::function<void (boost::shared_ptr<carla::sensor::SensorData>)>)::{lambda(auto:1)#1}>::_M_invoke(std::_Any_data const&, carla::Buffer&&) ()
    #17 0x00000000005ed938 in boost::asio::detail::completion_handler<boost::asio::detail::binder0<carla::streaming::detail::tcp::Client::ReadData()::{lambda()#1}::operator()() const::{lambda(boost::system::error_code, unsigned long)#1}::operator()(boost::system::error_code, unsigned long) const::{lambda()#1}>, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) ()
    #18 0x00000000005f8215 in boost::asio::detail::strand_service::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) ()
    #19 0x000000000053d6f4 in boost::asio::detail::scheduler::run(boost::system::error_code&) [clone .isra.0] ()
    #20 0x00000000005589fb in std::thread::_State_impl<std::thread::_Invoker<std::tuple<carla::ThreadPool::AsyncRun(unsigned long)::{lambda()#1}> > >::_M_run() ()
    #21 0x00007ffff6eed0a4 in execute_native_thread_routine () from /nix/store/6kbrc4ca98srlfpgyaayl2q9zpg1gys6-gcc-14-20241116-lib/lib/libstdc++.so.6
    #22 0x00007ffff6a972e3 in start_thread (arg=<optimized out>) at pthread_create.c:447
    #23 0x00007ffff6b1b2fc in __GI___clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78