### PR TITLE
fix param dump bug by changing decoder param sep from . to _

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,8 @@ on:
       branches: [master]
 
 jobs:
-   build_ros2:
-      uses: ros-misc-utilities/ros_build_scripts/.github/workflows/ros2_recent_ci.yml@master
-      with:
-         repo: ${{ github.event.repository.name }}
-         vcs_url: https://raw.githubusercontent.com/${{ github.repository }}/master/${{ github.event.repository.name }}.repos
+  build_ros2:
+    uses: ros-misc-utilities/ros_build_scripts/.github/workflows/ci_humble_and_later.yml@master
+    with:
+      repo: ${{ github.event.repository.name }}
+      vcs_url: ${{ github.event.repository.name }}.repos

--- a/src/subscriber.cpp
+++ b/src/subscriber.cpp
@@ -96,7 +96,7 @@ std::string Subscriber::getDecodersFromMap(const std::string & encoding)
   for (int i = static_cast<int>(x.size()); i > 0; --i) {
     std::string p_name;
     for (int j = 0; j < i; j++) {
-      p_name += "." + x[j];
+      p_name += (j == 0 ? "." : "_") + x[j];
     }
     ParameterDefinition pdef{
       PValue(""), PDescriptor()


### PR DESCRIPTION
This PR only affects the (unsupported!) subscriber node.