### PR TITLE
in cmake file use correct image transport version 5.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(rcutils REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 
-if(${image_transport_VERSION} VERSION_GREATER_EQUAL "5.1.7")
+if(${image_transport_VERSION} VERSION_GREATER_EQUAL "5.0.0")
   add_definitions(-DIMAGE_TRANSPORT_USE_PUBLISHER_T)
   add_definitions(-DIMAGE_TRANSPORT_NEEDS_PUBLISHEROPTIONS)
 endif()


### PR DESCRIPTION
This addresses an issue discovered for the ffmpeg image transport:
https://github.com/ros-misc-utilities/ffmpeg_image_transport/issues/52